### PR TITLE
Fix untranslatable strings

### DIFF
--- a/addon/globalPlugins/AIContentDescriber/__init__.py
+++ b/addon/globalPlugins/AIContentDescriber/__init__.py
@@ -323,7 +323,7 @@ class GlobalPlugin(GlobalPlugin):
 			file = snap[0]
 			if service.supported_formats and not os.path.splitext(file)[1].lower() in service.supported_formats:
 				# Translators: Message spoken when the image on the clipboard is not a format supported by the current description service
-				unsupported_format_msg = _(f"Unsupported image format. Please copy another file to the clipboard that is {''.join(service.supported_formats)}")
+				unsupported_format_msg = _("Unsupported image format. Please copy another file to the clipboard that is {formats}").format(formats=', '.join(service.supported_formats))
 				ui.message(unsupported_format_msg)
 				return
 			return threading.Thread(target=self.describe_image, kwargs={"file":file, "delete":False}).start()
@@ -347,7 +347,7 @@ class GlobalPlugin(GlobalPlugin):
 			return
 		tones.beep(300, 200)
 		# Translators: Message spoken after the beep - when we have started fetching the description
-		wx.CallAfter(ui.message, _(f"Retrieving description using {service.name}..."))
+		wx.CallAfter(ui.message, _("Retrieving description using {name}...").format(name=service.name))
 		message = service.process(file, **ch.config[service.name])
 		if ch.config["global"]["open_in_dialog"]:
 			# Translators: Title of the browseable message

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -418,7 +418,7 @@ class Gemini(BaseDescriptionService):
 		response = json.loads(response.decode('utf-8'))
 		if "error" in response:
 			#translators: message spoken when Google gemini encounters an error with the format or content of the input.
-			ui.message(_(f"Gemini encountered an error: {response['error']['code']}, {response['error']['message']}"))
+			ui.message(_("Gemini encountered an error: {code}, {msg}").format(code=response['error']['code'], msg=response['error']['message']))
 			return
 		content = response["candidates"][0]["content"]["parts"][0]["text"]
 		if content:
@@ -482,7 +482,7 @@ class Anthropic(BaseDescriptionService):
 		response = json.loads(response.decode('utf-8'))
 		if response["type"] == "error":
 			#translators: message spoken when Claude encounters an error with the format or content of the input.
-			ui.message(_(f"Claude encountered an error. {response['error']['message']}"))
+			ui.message(_("Claude encountered an error. {err}").format(err=response['error']['message']))
 			return
 		return response["content"][0]["text"]
 
@@ -550,7 +550,7 @@ This add-on integration assumes that you have obtained llama.cpp from Github and
 		response = post(url=url, headers=headers, data=json.dumps(payload).encode("utf-8"), timeout=self.timeout)
 		response = json.loads(response.decode('utf-8'))
 		if not "content" in response:
-			ui.message(_(f"Image recognition response appears to be malformed.\n{repr(response)}"))
+			ui.message(_("Image recognition response appears to be malformed.\n{response}").format(response=repr(response)))
 		return response["content"]
 
 

--- a/addon/globalPlugins/AIContentDescriber/face_view.py
+++ b/addon/globalPlugins/AIContentDescriber/face_view.py
@@ -124,7 +124,7 @@ class FaceDetectionInterface:
 				wx.CallAfter(ui.message, _("The footage from the camera is too blurry. Try switching your focus away from the desktop, then try this command again."))
 				return
 			# translators: message spoken when the face detection fails because the camera encountered a blurry image
-			wx.CallAfter(ui.message, _(f"The footage from the camera is too blurry. Please ensure that it is not covered up and that your surroundings have proper lighting. {int(laplacian_variance)}"))
+			wx.CallAfter(ui.message, _("The footage from the camera is too blurry. Please ensure that it is not covered up and that your surroundings have proper lighting. {}").format(int(laplacian_variance)))
 			return
 		faces = self.face_cascade.detectMultiScale(gray, 1.1, 6, minSize=(60, 60))
 		if len(faces) == 0:


### PR DESCRIPTION
Hi!
Here is a PR to fix an issue with string translation

### Issue
You cannot use f-strings for translatable strings. Else, the f-string is first interpolated and then a translation is looked for for this interpolated string rather than for the original string with placeholders (`{}`).

### Solution
Instead of the f-string usage as follows:
`_(f"The length of an empty list is: {len([])}")`

Use the `.format` following syntax:
`_("The length of an empty list is: {}".format(len([])))`

Note: While at it, I have also fixed how supported formats are reported, since there were no space nor separators between each format of the list.
