### PR TITLE
Cache Refactor

### DIFF
--- a/addon/globalPlugins/AIContentDescriber/cache.py
+++ b/addon/globalPlugins/AIContentDescriber/cache.py
@@ -8,30 +8,31 @@ import os
 import json
 import globalVars
 
-
-CACHE_FILE = "images.cache"
-CACHE_PATH = os.path.abspath(os.path.join(globalVars.appArgs.configPath, CACHE_FILE))
 cache = {}
 
+def _get_cache_path(cache_name):
+	return os.path.abspath(os.path.join(globalVars.appArgs.configPath, cache_name + ".cache"))
 
-def create_cache():
+def create_cache(cache_name):
 	global cache
-	cache = {}
-	write_cache()  # create the file
+	cache[cache_name]= {}
+	write_cache(cache_name)  # create the file
 
 
-def read_cache():
+def read_cache(cache_name):
 	global cache
-	if not os.path.isfile(CACHE_PATH):
-		create_cache()
+	cache_path = _get_cache_path(cache_name)
+	if not os.path.isfile(cache_path):
+		create_cache(cache_name)
 		return
 	try:
-		with open(CACHE_PATH, "r") as f:
-			cache = json.load(f)
+		with open(cache_path, "r") as f:
+			cache[cache_name] = json.load(f)
 	except json.decoder.JSONDecodeError:  #  todo: try to fix corrupt files before trashing them
-		create_cache()
+		create_cache(cache_name)
 
 
-def write_cache():
-	with open(CACHE_PATH, "w") as f:
-		json.dump(cache, f, indent="\t")
+def write_cache(cache_name):
+	cache_path = _get_cache_path(cache_name)
+	with open(cache_path, "w") as f:
+		json.dump(cache[cache_name], f, indent="\t")

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -10,6 +10,8 @@ import os.path
 import tempfile
 import urllib.parse
 import urllib.request
+import logHandler
+log = logHandler.log
 
 import addonHandler
 try:
@@ -211,9 +213,11 @@ class CachedDescriptionService(BaseDescriptionService):
 				cache.read_cache(self.FALLBACK_CACHE_NAME)
 				description = cache.cache[self.FALLBACK_CACHE_NAME].get(base64_image)
 			if description is not None:
+				log.debug(f"Cache hit. Using cached description for {image_path} from {self.name}")
 				return description
 
 		# delegate to the wrapped description service
+		log.debug(f"Cache miss. Fetching description for {image_path} from {self.name}")
 		description = self.description_service.process(image_path, **kw)
 
 		# (optionally) update the cache

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -188,6 +188,9 @@ class CachedDescriptionService(BaseDescriptionService):
 	description_service = CachedDescriptionService(GPT4())
 	```
 	"""
+
+	# TODO: remove fallback cache in later versions
+	FALLBACK_CACHE_NAME = "images"
 	
 	def __init__(self, description_service: BaseDescriptionService):
 		# copy all class variables from the wrapped description service
@@ -201,8 +204,12 @@ class CachedDescriptionService(BaseDescriptionService):
 
 		# (optionally) read the cache
 		if is_cache_enabled:
-			cache.read_cache()
-			description = cache.cache.get(base64_image)
+			cache.read_cache(self.name)
+			description = cache.cache[self.name].get(base64_image)
+			if description is None:
+				# TODO: remove fallback cache in later versions
+				cache.read_cache(self.FALLBACK_CACHE_NAME)
+				description = cache.cache[self.FALLBACK_CACHE_NAME].get(base64_image)
 			if description is not None:
 				return description
 
@@ -211,9 +218,9 @@ class CachedDescriptionService(BaseDescriptionService):
 
 		# (optionally) update the cache
 		if is_cache_enabled:
-			cache.read_cache()
-			cache.cache[base64_image] = description
-			cache.write_cache()
+			cache.read_cache(self.name)
+			cache.cache[self.name][base64_image] = description
+			cache.write_cache(self.name)
 		
 		return description
 


### PR DESCRIPTION
## What type of PR is this?
- [ ] 🤩 Feature
- [x] 🪲 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test

## Description of changes
- Moved cache logic from description services (`GPT4`, `LlamaCPP`, ...) to a new description service wrapper class: `CachedDescriptionService`. Then wrapped each model's description service in the `CachedDescriptionService`. This fixed a bug where the cache was only updated by OpenAI description services. 
- Modified cache to use multiple files (1 per description service + the original cache file) instead of just 1 file. The original cache file is now just a read-only fallback and no longer updated. 

## Related issues
closes #32

## How was this tested?
Manual testing!

Test cases:
 - [x] no cache, describe new image
 - [x] fallback cache, describe new image
 - [x] fallback cache, describe image from fallback cache
 - [x] all caches, describe new image
 - [x] all caches, describe image from model's cache
 - [x] all caches, describe image from fallback cache

For each test case, checked that the following occur as expected and only when expected:
 - [x] create cache file when file does not exist
 - [x] skip API call after cache hit
 - [x] do API call after cache miss
 - [x] write to cache file after API call

All tests performed with Claude 3 Haiku and NVDA+Shift+Y.
