### PR TITLE
Add Seer provider: local PaliGemma2 image descriptions

### DIFF
--- a/addon/globalPlugins/AIContentDescriber/configspec.py
+++ b/addon/globalPlugins/AIContentDescriber/configspec.py
@@ -304,6 +304,11 @@ max_tokens = integer(default=250)
 cache_descriptions = boolean(default=False)
 timeout = integer(default=30, min=1)
 
+[Seer]
+base_url = string(default="http://127.0.0.1:11435")
+cache_descriptions = boolean(default=False)
+timeout = integer(default=60, min=1)
+
 [global]
 optimize_for_size = boolean(default=False)
 open_in_dialog = boolean(default=True)

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -1464,10 +1464,7 @@ class Seer(BaseDescriptionService):
 
 	def add_to_conversation(self, user_message, image_path=None, include_original_image=True):
 		# PaliGemma2 is a captioner, not a conversational model
-		return _(
-			"Seer uses PaliGemma2 which describes images but does not support "
-			"follow-up questions. Press the describe shortcut again for a new description."
-		)
+		return _("Seer uses PaliGemma2 which describes images but does not support follow-up questions.")
 
 
 models = [

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -1460,7 +1460,6 @@ class Seer(BaseDescriptionService):
 		content = resp_json.get("description", "").strip()
 		if not content:
 			return None
-		self.start_conversation(image_path, None, content)
 		return content
 
 	def add_to_conversation(self, user_message, image_path=None, include_original_image=True):

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -1438,6 +1438,7 @@ class Seer(BaseDescriptionService):
 	description = _(
 		"Private, on-device image descriptions using PaliGemma2. "
 		"No API key or cloud connection required. "
+		"Note: this is a captioning model, prompts and follow-up questions are not supported. "
 		"Install the Seer daemon to get started."
 	)
 	about_url = "https://github.com/recursia-lab/Seer"

--- a/addon/globalPlugins/AIContentDescriber/description_service.py
+++ b/addon/globalPlugins/AIContentDescriber/description_service.py
@@ -1430,6 +1430,46 @@ class VivoBlueLMVision(BaseDescriptionService):
 			return str(e)
 
 
+class Seer(BaseDescriptionService):
+	name = "Seer"
+	needs_api_key = False
+	needs_base_url = True
+	# translators: description of the Seer local vision provider
+	description = _(
+		"Private, on-device image descriptions using PaliGemma2. "
+		"No API key or cloud connection required. "
+		"Install the Seer daemon to get started."
+	)
+	about_url = "https://github.com/recursia-lab/Seer"
+	supported_formats = [".jpeg", ".jpg", ".png", ".webp", ".bmp"]
+
+	@cached_description
+	def process(self, image_path, **kw):
+		base64_image = encode_image(image_path)
+		payload = json.dumps({
+			"image_b64": base64_image,
+			"task": "caption",
+		}).encode("utf-8")
+		headers = {"Content-Type": "application/json"}
+		url = urllib.parse.urljoin(self.base_url.rstrip("/") + "/", "describe")
+		response = post(url=url, headers=headers, data=payload, timeout=self.timeout)
+		if not response:
+			return None
+		resp_json = json.loads(response.decode("utf-8"))
+		content = resp_json.get("description", "").strip()
+		if not content:
+			return None
+		self.start_conversation(image_path, None, content)
+		return content
+
+	def add_to_conversation(self, user_message, image_path=None, include_original_image=True):
+		# PaliGemma2 is a captioner, not a conversational model
+		return _(
+			"Seer uses PaliGemma2 which describes images but does not support "
+			"follow-up questions. Press the describe shortcut again for a new description."
+		)
+
+
 models = [
 	PollinationsAI(),
 	GPT4O(),
@@ -1473,6 +1513,7 @@ models = [
 	Ollama(),
 	LlamaCPP(),
 	LiteLLMProxy(),
+	Seer(),
 ]
 
 

--- a/addon/globalPlugins/AIContentDescriber/model_configuration.py
+++ b/addon/globalPlugins/AIContentDescriber/model_configuration.py
@@ -396,6 +396,18 @@ class LlamaCPPConfigurationPanel(BaseModelSettingsPanel):
 		super().makeSettings(settingsSizer)
 
 
+class SeerConfigurationPanel(BaseModelSettingsPanel):
+	model = description_service.Seer()
+	# Translators: Requires installation
+	title = model.name + _(" (requires installation)")
+	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		self.add_about_button(sHelper)
+		self.add_base_url_field(sHelper)
+		self.add_timeout_field(sHelper)
+		super().makeSettings(settingsSizer)
+
+
 class ClaudeConfigurationPanel(BaseModelSettingsPanel):
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
@@ -535,6 +547,7 @@ description_service.Claude4_5Haiku.configurationPanel = Claude4_5HaikuConfigurat
 description_service.Claude4_6Sonnet.configurationPanel = Claude4_6SonnetConfigurationPanel
 description_service.Claude4_6Opus.configurationPanel = Claude4_6OpusConfigurationPanel
 description_service.LiteLLMProxy.configurationPanel = LiteLLMProxyConfigurationPanel
+description_service.Seer.configurationPanel = SeerConfigurationPanel
 models_dialog_parent = None
 
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Leveraging the multimodal capabilities of advanced AI models and computer vision
 * Describe any image that has been copied to the clipboard, be it a picture from an email or a path in windows explorer
 * Indicate whether the user's face is positioned at the center of the frame using computer vision algorithms (does not require paid API access)
 * Free to use by default, optionally add your own API key for more models
-* Supports multiple providers (OpenAI's GPT and the free Pollinations tier, Google's Gemini, Mistral's Pixtral Large, Anthropic's Claude, xAI's Grok, vivo BlueLM Vision via NVDA-CN, Ollama, llama.cpp, and LiteLLM Proxy)
+* Supports multiple providers (OpenAI's GPT and the free Pollinations tier, Google's Gemini, Mistral's Pixtral Large, Anthropic's Claude, xAI's Grok, vivo BlueLM Vision via NVDA-CN, Ollama, llama.cpp, LiteLLM Proxy, and Seer)
 * Supports a wide variety of formats including PNG (.png), JPEG (.jpeg and .jpg), WEBP (.webp), and non-animated GIF (.gif)
 * Optionally caches responses to preserve API quota
 * For advanced use, customize the prompt and token count to tailor information to your needs
@@ -46,6 +46,7 @@ Now, the possibilities are almost endless. You might:
 * [Ollama (unstable)](https://ollama.com/)
 * [llama.cpp (extremely unstable and slow depending on your hardware, tested to work with llava-v1.5/1.6, BakLLaVA, Obsidian, and MobileVLM 1.7B/3B models)](https://github.com/ggerganov/llama.cpp)
 * [LiteLLM Proxy](https://docs.litellm.ai/docs/proxy/quick_start): Access multiple AI models through a unified proxy server. Requires a LiteLLM proxy server URL, optionally an API key depending on your proxy configuration. Appears as "LiteLLM Proxy" in the model configuration dialog. Supports dynamic model selection and follow-up questions. Compatible with all formats (PNG, JPEG, WEBP, GIF).
+* [Seer](https://github.com/recursia-lab/Seer): Runs PaliGemma2 locally via the Seer daemon. No API key or internet connection required. Note: this is a captioning-only model. Prompts and follow-up questions are not supported.
 
 Follow the instructions provided below to get each of these working.
 
@@ -176,6 +177,15 @@ This will start a proxy server at `http://localhost:4000` that forwards requests
 8. Adjust other settings like prompt, max tokens, and timeout as needed, then click OK.
 
 Note: The models available and their capabilities depend on your LiteLLM proxy configuration. Ensure your proxy is configured with vision-capable models for image description.
+
+### Setting up Seer
+
+Seer runs PaliGemma2 on your own machine with no API key or cloud connection required. Note that this is a captioning-only model; prompts and follow-up questions are not supported.
+
+1. Install the [Seer daemon](https://github.com/recursia-lab/Seer). A one-command installer is provided for Windows (.bat) and Linux/macOS (.sh).
+2. In the NVDA settings dialog, navigate to the AI Content Describer category, choose "manage models (alt+m)", and select "Seer (requires installation)".
+3. The base URL defaults to `http://127.0.0.1:11435`. Leave it as-is unless you changed the daemon's port.
+4. Click OK. The daemon must be running before you attempt a description.
 
 ## Usage
 


### PR DESCRIPTION
  ## What this adds
                   
  A new **Seer** provider that calls a local [Seer daemon](https://github.com/recursia-lab/Seer) running PaliGemma2 on the user's own machine. No API key, no cloud, no subscription.
                                                                                                                                                                                                 
  User presses Alt+NVDA+I
          ↓                                                                                                                                                                                      
  AI Content Describer → POST http://127.0.0.1:11435/describe     
          ↓                                                                                                                                                                                      
  Seer daemon (local) → PaliGemma2
          ↓                                                                                                                                                                                      
  "A golden retriever running on a beach"                         
          ↓
  NVDA speaks the description
                                                                                                                                                                                                 
  ## Why PaliGemma2?
                                                                                                                                                                                                 
  PaliGemma2 (Google, 3B parameters) is purpose-built for image captioning — short, accurate descriptions ideal for screen readers. The Q4_K_M GGUF runs on ~3 GB RAM with no GPU required.      
  
  We recently added PaliGemma2 support to llama.cpp ([PR #22528](https://github.com/ggml-org/llama.cpp/pull/22528)), enabling it to run via Ollama. The Seer daemon also supports moondream/llava
   today, so it works on Windows, macOS, and Linux right now.     
                                                                                                                                                                                                 
  ## Changes (59 lines, 3 files)                                                                                                                                                                 
  
  - `description_service.py`: `Seer` class — calls `/describe`, graceful message for follow-up questions                                                                                         
  - `model_configuration.py`: `SeerConfigurationPanel` — base URL + timeout only, no API key
  - `configspec.py`: `[Seer]` config section (default `http://127.0.0.1:11435`)                                                                                                                  
                                                                                                                                                                                                 
  ## Setup for users
                                                                                                                                                                                                 
  1. Install [Seer daemon](https://github.com/recursia-lab/Seer) (one-command installer: Windows `.bat` / Linux+Mac `.sh`)                                                                       
  2. NVDA settings → AI Content Describer → select **Seer (requires installation)**
  3. Base URL defaults to `http://127.0.0.1:11435` — no changes needed                                                                                                                           
                                                                                                      